### PR TITLE
Update verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/setup-python@v1
 
     - name: Install dependencies
-      run: pip3 install -U git+https://github.com/kmyk/online-judge-verify-helper.git@master
+      run: pip3 install -U online-judge-verify-helper
 
     - name: Run tests
       env:


### PR DESCRIPTION
このプルリクエストは online-judge-verify-helper をインストールするための指定を修正します。
`git+https://github.com/kmyk/online-judge-verify-helper.git@master` は GitHub レポジトリの `master` ブランチを使ってしまうので動作はしますがすこし不安定であり、`online-judge-verify-helper` と書けば [PyPI](https://pypi.org/project/online-judge-verify-helper/) 経由の明示的にリリースされたバージョンが使われるのでより安定します。具体的には「私などが開発中にうっかり間違えた commit をしたあおりを受けてこのライブラリの CI が落ちる」という不幸がなくなります。

(おそらく https://kmyk.github.io/online-judge-verify-helper/installer.html を使って導入してくれたのだと思いますが、このインストーラーは更新がすこし遅れていたため不適切な状態にありました。いまは修正されています。:bow:)